### PR TITLE
Add contributing guidelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
 # These owners will be the default owners for everything in
 # the repository and will be requested for review.
+
+# Curriculum Development team.
 *       @jtascensao @PedroGFonseca
+
+# Add Specialization Leads.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo.
+*       @jtascensao @PedroGFonseca

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
-# the repo.
+# the repository and will be requested for review.
 *       @jtascensao @PedroGFonseca

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+# Title
+
+## Context
+
+> Why is the change or addition important?
+
+## Detailed Description
+
+> Provide a detailed description of the change or addition.
+
+## Possible Implementation
+
+> Suggest an idea for implementing the changes.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,6 +8,10 @@
 
 > Provide a detailed description of the change or addition.
 
+> What Specialization, BLU, or SLU is it a part of (if any)?
+
 ## Possible Implementation
 
 > Suggest an idea for implementing the changes.
+
+> This does not need to be a fully-fledged plan but at least provide a concrete starting point.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,7 @@
 # Title
 
+> Make sure you use a descriptive subject line and the appropriate tags.
+
 ## Context
 
 > Why is the change or addition important?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,10 +10,6 @@ If you haven't, go over the Contributing Guidelines.
 
 - [ ] I have read the **CONTRIBUTING** document.
 
-## Description
-
-> Describe your changes in detail.
-
 ## Related Issue
 
 **This project only accepts pull requests related to open issues.**
@@ -21,3 +17,9 @@ If you haven't, go over the Contributing Guidelines.
 If suggesting a new feature or change, please discuss it in an issue first.
 
 > Please link to the issue here.
+
+## Description
+
+> You may refer to the original issue if it has enough context.
+
+> If anything changed since the original issue was logged, make a note of it here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,8 @@
+> Use a descriptive subject and the prefixes WIP and RFC for state.
+
 Closes
+
+> Mention the issues this PR addresses above, example: Closes #1, #2
 
 # Title
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+Closes
+
+# Title
+
+## Contributing Guidelines
+
+If you haven't, go over the Contributing Guidelines.
+
+> Put an `x` in the box if you did.
+
+- [ ] I have read the **CONTRIBUTING** document.
+
+## Description
+
+> Describe your changes in detail.
+
+## Related Issue
+
+**This project only accepts pull requests related to open issues.**
+
+If suggesting a new feature or change, please discuss it in an issue first.
+
+> Please link to the issue here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-When contributing to this repository, please start by discussing the change via [issue](https://github.com/LDSSA/curriculum-development/issues) or in the `#curriculum` Slack channel.
+Please start by discussing the change via [issue](https://github.com/LDSSA/curriculum-development/issues) or in the `#curriculum` Slack channel.
 
 # Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ For Specializations with a Lead assigned, further curriculum changes need to be 
 * João Ascensão (@jtascensao)
 * Pedro Fonseca (@PedroGfonseca)
 
+# Specialization Leads
+
 # Milestones (Batch 3)
 
 **Submit ideas before the 18th of March.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+When contributing to this repository, please discuss the change via [issue](https://github.com/LDSSA/curriculum-development/issues).
+
+Alternatively, raise the topic in the `#curriculum` Slack channel.
+
+## Pull Request Process
+
+We use the [GitHub flow](https://guides.github.com/introduction/flow/).
+
+1. Create a new branch, following the convention `ISSUE_NUMBER/ISSUE_TITLE` when naming the branch)
+2. Update the file(s) with the proposed changes
+3. Commit the proposed changes
+4. Open a Pull Request to discuss the changes
+5. Notify the `#curriculum` Slack channel to trigger the approval process.
+
+## Approval Process
+
+1. Anyone on `#curriculum` can discuss, review, or upvote Pull Requests
+2. Reviews by Teaching, Quality Assurance, and Student Success are optional but encouraged
+3. Final approval by the Curriculum Development team (merge and close the issue).
+
+For Specializations with Leads assigned, curriculum changes need to be approved by the Specialization Lead.
+
+## Curriculum Development Team
+
+* João Ascensão (@jtascensao)
+* Pedro Fonseca (@PedroGFonseca)
+
+## Timelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 2. Reviews by Teaching, Quality Assurance, and Student Success are optional but encouraged
 3. Final approval by the Curriculum Development team (merge and close the issue, notify on `#curriculum`).
 
-For Specializations with Leads assigned, further curriculum changes need to be approved by the Specialization Lead.
+For Specializations with a Lead assigned, further curriculum changes need to be approved by the Specialization Lead.
 
 # Curriculum Development Team
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ Contributing Guidelines
 1. [Code of Conduct](#code-of-conduct)
 2. [Teaching Philosophy](#teaching-philosophy)
 3. [Contributing](#contributing)
-  1. [Pull Request Process](#pull-request-process)
-  2. [Approval Process](#approval-process)
-  3. [Specialization Leads](#specialization-leads)
-4. [Milestones](#milestones)
-5. [Curriculum Team](#curriculum-development-team)
+4. [Pull Request Process](#pull-request-process)
+5. [Approval Process](#approval-process)
+6. [Specialization Leads](#specialization-leads)
+7. [Milestones](#milestones)
+8. [Curriculum Team](#curriculum-development-team)
 
 ## Code of Conduct
 
@@ -22,7 +22,7 @@ LDSSA's [Teaching Philosophy](https://github.com/LDSSA/wiki/wiki/Teaching-Philos
 
 Please start by discussing the change via [issue](https://github.com/LDSSA/curriculum-development/issues).
 
-### Pull Request Process
+## Pull Request Process
 
 We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 
@@ -31,22 +31,22 @@ We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 3. Commit the proposed changes
 4. Open a Pull Request to discuss the changes.
 
-### Approval Process
+## Approval Process
 
 1. Anyone on `#curriculum` can discuss, review, or upvote/downvote Pull Requests
 2. Reviews by Teaching, Quality Assurance, and Student Success are optional but encouraged
 3. Final approval by the Curriculum Development team (merge to master and close the issue).
 
-### Specialization Leads
+## Specialization Leads
 
 Specialization Leads are responsible for refining the curriculum, as follows:
 
 1. The Curriculum Team develops a detailed draft of the Specialization's curriculum
-2. Leads are assigned to Specializations, in accordance with the curriculum
-3. The curriculum is a contract that is binding for the Lead and the Curriculum Team
-4. From the assignment onwards, Leads also need to approve contract changes
-5. The Specialization Leads refine the curriculum
-6. Refinements need to be approved by the Curriculum Team **until 6 weeks before the start of the Specialization**.
+2. Leads are assigned to Specializations, in accordance with the defined curriculum
+3. The curriculum is a "contract" that is binding for the Lead and the Curriculum Team
+4. From the assignment onwards, Leads also need to approve changes
+5. Specialization Leads can refine the curriculum
+6. Refinements are approved by the Curriculum Team **until 6 weeks before the start of the Specialization**.
 
 ## Milestones
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ LDSSA's [Teaching Philosophy](https://github.com/LDSSA/wiki/wiki/Teaching-Philos
 
 We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 
-1. Create a new branch, following the convention `ISSUE_NUMBER/ISSUE_TITLE` when naming the branch)
+1. Create a new branch, following the naming convention `ISSUE_NUMBER/ISSUE_TITLE`
 2. Update the file(s) with the proposed changes
 3. Commit the proposed changes
 4. Open a Pull Request to discuss the changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ For Specializations with a Lead assigned, further changes need to be approved by
 
 # Milestones (Batch 3)
 
-**Submit ideas before the 18th of March.**
+**Submit ideas before the 15th of March.**
 
 New discussions after these dates will be considered for the next Batch.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,13 @@ We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 2. Update the file(s) with the proposed changes
 3. Commit the proposed changes
 4. Open a Pull Request to discuss the changes
-5. Notify the `#curriculum` Slack channel to trigger the approval process.
+5. ~~Notify the `#curriculum` Slack channel to trigger the approval process~~.
 
 # Approval Process
 
 1. Anyone on `#curriculum` can discuss, review, or upvote/downvote Pull Requests
 2. Reviews by Teaching, Quality Assurance, and Student Success are optional but encouraged
-3. Final approval by the Curriculum Development team (merge and close the issue, notify on `#curriculum`).
+3. Final approval by the Curriculum Development team (merge and close the issue, ~~notify on `#curriculum`~~).
 
 For Specializations with a Lead assigned, further changes need to be approved by the Specialization Lead.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 
 ## Approval Process
 
-1. Anyone on `#curriculum` can discuss, review, or upvote Pull Requests
+1. Anyone on `#curriculum` can discuss, review, or upvote/downvote Pull Requests
 2. Reviews by Teaching, Quality Assurance, and Student Success are optional but encouraged
 3. Final approval by the Curriculum Development team (merge and close the issue).
 
@@ -25,6 +25,17 @@ For Specializations with Leads assigned, curriculum changes need to be approved 
 ## Curriculum Development Team
 
 * João Ascensão (@jtascensao)
-* Pedro Fonseca (@PedroGFonseca)
+* Pedro Fonseca (@PedroGfonseca)
 
-## Timelines
+## Milestones (Batch 3)
+
+**Submit ideas before the 18th of March.**
+
+| Date                                            | Milestone                  | Enabler     |
+|-------------------------------------------------|----------------------------|-------------|
+| 15 March                                        | Call for ideas             | @jtascensao |
+| 18 March                                        | Curriculum first draft     | @jtascensao |
+| 31 March                                        | Close curriculum           | @jtascensao |
+| 6 weeks before the start of each Specialization | Submit detailed curriculum | Specialization Leads |
+
+Ideas submitted after these dates will be considered for the next Batch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,15 @@ When contributing to this repository, please discuss the change via [issue](http
 
 Alternatively, raise the topic in the `#curriculum` Slack channel.
 
-## Pull Request Process
+# Code of Conduct
+
+LDSSA's [Code of Conduct](https://github.com/LDSSA/wiki/wiki/Code-of-Conduct).
+
+# Teaching Philosophy
+
+LDSSA's [Teaching Philosophy](https://github.com/LDSSA/wiki/wiki/Teaching-Philosophy).
+
+# Pull Request Process
 
 We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 
@@ -14,7 +22,7 @@ We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 4. Open a Pull Request to discuss the changes
 5. Notify the `#curriculum` Slack channel to trigger the approval process.
 
-## Approval Process
+# Approval Process
 
 1. Anyone on `#curriculum` can discuss, review, or upvote/downvote Pull Requests
 2. Reviews by Teaching, Quality Assurance, and Student Success are optional but encouraged
@@ -22,20 +30,20 @@ We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 
 For Specializations with Leads assigned, curriculum changes need to be approved by the Specialization Lead.
 
-## Curriculum Development Team
+# Curriculum Development Team
 
 * João Ascensão (@jtascensao)
 * Pedro Fonseca (@PedroGfonseca)
 
-## Milestones (Batch 3)
+# Milestones (Batch 3)
 
 **Submit ideas before the 18th of March.**
 
-| Date                                            | Milestone                  | Enabler     |
-|-------------------------------------------------|----------------------------|-------------|
-| 15 March                                        | Call for ideas             | @jtascensao |
-| 18 March                                        | Curriculum first draft     | @jtascensao |
-| 31 March                                        | Close curriculum           | @jtascensao |
-| 6 weeks before the start of each Specialization | Submit detailed curriculum | Specialization Leads |
+New discussions after these dates will be considered for the next Batch.
 
-Ideas submitted after these dates will be considered for the next Batch.
+| Date                                              | Milestone                  | Enabler     |
+|---------------------------------------------------|----------------------------|-------------|
+| 15th March                                        | Call for ideas             | @jtascensao |
+| 18th March                                        | Curriculum first draft     | @jtascensao |
+| 31st March                                        | Close curriculum           | @jtascensao |
+| 6 weeks before the start of each Specialization   | Submit detailed curriculum | Specialization Leads |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,28 @@
-# Contributing
+Contributing Guidelines
+=================
 
-Please start by discussing the change via [issue](https://github.com/LDSSA/curriculum-development/issues).
+1. [Code of Conduct](#code-of-conduct)
+2. [Teaching Philosophy](#teaching-philosophy)
+3. [Contributing](#contributing)
+  1. [Pull Request Process](#pull-request-process)
+  2. [Approval Process](#approval-process)
+  3. [Specialization Leads](#specialization-leads)
+4. [Milestones](#milestones)
+5. [Curriculum Team](#curriculum-development-team)
 
-# Code of Conduct
+## Code of Conduct
 
 LDSSA's [Code of Conduct](https://github.com/LDSSA/wiki/wiki/Code-of-Conduct).
 
-# Teaching Philosophy
+## Teaching Philosophy
 
 LDSSA's [Teaching Philosophy](https://github.com/LDSSA/wiki/wiki/Teaching-Philosophy).
 
-# Pull Request Process
+## Contributing
+
+Please start by discussing the change via [issue](https://github.com/LDSSA/curriculum-development/issues).
+
+### Pull Request Process
 
 We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 
@@ -19,22 +31,24 @@ We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 3. Commit the proposed changes
 4. Open a Pull Request to discuss the changes.
 
-# Approval Process
+### Approval Process
 
 1. Anyone on `#curriculum` can discuss, review, or upvote/downvote Pull Requests
 2. Reviews by Teaching, Quality Assurance, and Student Success are optional but encouraged
 3. Final approval by the Curriculum Development team (merge to master and close the issue).
 
-For Specializations with a Lead assigned, further changes need to be approved by the Specialization Lead.
+### Specialization Leads
 
-# Curriculum Development Team
+Specialization Leads are responsible for refining the curriculum, as follows:
 
-* João Ascensão (@jtascensao)
-* Pedro Fonseca (@PedroGfonseca)
+1. The Curriculum Team develops a detailed draft of the Specialization's curriculum
+2. Leads are assigned to Specializations, in accordance with the curriculum
+3. The curriculum is a contract that is binding for the Lead and the Curriculum Team
+4. From the assignment onwards, Leads also need to approve contract changes
+5. The Specialization Leads refine the curriculum
+6. Refinements need to be approved by the Curriculum Team **until 6 weeks before the start of the Specialization**.
 
-# Specialization Leads
-
-# Milestones (Batch 3)
+## Milestones
 
 **Submit ideas before the 15th of March.**
 
@@ -48,3 +62,10 @@ Find the important dates for Curriculum Development below.
 | 18th March                                        | Curriculum first draft     | @jtascensao |
 | 31st March                                        | Close curriculum           | @jtascensao |
 | 6 weeks before the start of each Specialization   | Submit detailed curriculum | Specialization Leads |
+
+## Curriculum Team
+
+| Team Member   | Email                                        |
+|---------------|----------------------------------------------|
+| João Ascensão (@jtascensao) | ascensao@lisbondatascience.org |
+| Pedro Fonseca (@PedroGfonseca) | pedro@lisbondatascience.org  |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Specialization Leads are responsible for refining the curriculum, as follows:
 2. Leads are assigned to Specializations, in accordance with the defined curriculum
 3. The curriculum is a "contract" that is binding for the Lead and the Curriculum Team
 4. From the assignment onwards, Leads also need to approve changes
-5. Specialization Leads refine the curriculum
+5. Specialization Leads refine the curriculum, if they so desire
 6. Refinements approved by the Curriculum Team **until 6 weeks** before the start of the Specialization.
 
 ## Milestones

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 2. Reviews by Teaching, Quality Assurance, and Student Success are optional but encouraged
 3. Final approval by the Curriculum Development team (merge and close the issue, notify on `#curriculum`).
 
-For Specializations with a Lead assigned, further curriculum changes need to be approved by the Specialization Lead.
+For Specializations with a Lead assigned, further changes need to be approved by the Specialization Lead.
 
 # Curriculum Development Team
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ Specialization Leads are responsible for refining the curriculum, as follows:
 2. Leads are assigned to Specializations, in accordance with the defined curriculum
 3. The curriculum is a "contract" that is binding for the Lead and the Curriculum Team
 4. From the assignment onwards, Leads also need to approve changes
-5. Specialization Leads can refine the curriculum
-6. Refinements are approved by the Curriculum Team **until 6 weeks before the start of the Specialization**.
+5. Specialization Leads refine the curriculum
+6. Refinements approved by the Curriculum Team **until 6 weeks** before the start of the Specialization.
 
 ## Milestones
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,14 +17,13 @@ We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 1. Create a new branch, following the naming convention `ISSUE_NUMBER/ISSUE_TITLE`
 2. Update the file(s) with the proposed changes
 3. Commit the proposed changes
-4. Open a Pull Request to discuss the changes
-5. ~~Notify the `#curriculum` Slack channel to trigger the approval process~~.
+4. Open a Pull Request to discuss the changes.
 
 # Approval Process
 
 1. Anyone on `#curriculum` can discuss, review, or upvote/downvote Pull Requests
 2. Reviews by Teaching, Quality Assurance, and Student Success are optional but encouraged
-3. Final approval by the Curriculum Development team (merge and close the issue, ~~notify on `#curriculum`~~).
+3. Final approval by the Curriculum Development team (merge to master and close the issue).
 
 For Specializations with a Lead assigned, further changes need to be approved by the Specialization Lead.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Please start by discussing the change via [issue](https://github.com/LDSSA/curriculum-development/issues) or in the `#curriculum` Slack channel.
+Please start by discussing the change via [issue](https://github.com/LDSSA/curriculum-development/issues).
 
 # Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,6 @@
 # Contributing
 
-When contributing to this repository, please discuss the change via [issue](https://github.com/LDSSA/curriculum-development/issues).
-
-Alternatively, raise the topic in the `#curriculum` Slack channel.
+When contributing to this repository, please start by discussing the change via [issue](https://github.com/LDSSA/curriculum-development/issues) or in the `#curriculum` Slack channel.
 
 # Code of Conduct
 
@@ -26,9 +24,9 @@ We use the [GitHub flow](https://guides.github.com/introduction/flow/).
 
 1. Anyone on `#curriculum` can discuss, review, or upvote/downvote Pull Requests
 2. Reviews by Teaching, Quality Assurance, and Student Success are optional but encouraged
-3. Final approval by the Curriculum Development team (merge and close the issue).
+3. Final approval by the Curriculum Development team (merge and close the issue, notify on `#curriculum`).
 
-For Specializations with Leads assigned, curriculum changes need to be approved by the Specialization Lead.
+For Specializations with Leads assigned, further curriculum changes need to be approved by the Specialization Lead.
 
 # Curriculum Development Team
 
@@ -41,7 +39,9 @@ For Specializations with Leads assigned, curriculum changes need to be approved 
 
 New discussions after these dates will be considered for the next Batch.
 
-| Date                                              | Milestone                  | Enabler     |
+Find the important dates for Curriculum Development below.
+
+| Deadline                                          | Milestone                  | Enabler     |
 |---------------------------------------------------|----------------------------|-------------|
 | 15th March                                        | Call for ideas             | @jtascensao |
 | 18th March                                        | Curriculum first draft     | @jtascensao |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Curriculum Development
 
-Welcome to the Curriculum Development depository of the [Lisbon Data Science Starters Academy (LDSSA)](http://www.lisbondatascience.org/)! 🙌
+Welcome to the Curriculum Development repository of the [Lisbon Data Science Starters Academy (LDSSA)](http://www.lisbondatascience.org/)! 🙌
 
 ## Contributing
 
-Please read the [CONTRIBUTING]() file for details on code conduct, teaching philosophy, and guidelines.
+Please read the [CONTRIBUTING](https://github.com/LDSSA/curriculum-development/blob/1/contributing-guidelines/CONTRIBUTING.md) file for details on code conduct, teaching philosophy, and guidelines.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# curriculum-development
+# Curriculum Development
+
+Welcome to the Curriculum Development depository of the [Lisbon Data Science Starters Academy (LDSSA)](http://www.lisbondatascience.org/)! 🙌
+
+## Contributing
+
+Please read the [CONTRIBUTING]() file for details on code conduct, teaching philosophy, and guidelines.


### PR DESCRIPTION
Closes #1, #3 

Adds the following [Contributing Guidelines](https://github.com/LDSSA/curriculum-development/blob/1/contributing-guidelines/CONTRIBUTING.md), plus [Issue](https://github.com/LDSSA/curriculum-development/blob/1/contributing-guidelines/.github/ISSUE_TEMPLATE.md) and [Pull Request](https://github.com/LDSSA/curriculum-development/blob/1/contributing-guidelines/.github/PULL_REQUEST_TEMPLATE.md) templates.